### PR TITLE
fix: Add missing system for apple silicon

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -11,6 +11,7 @@
       "x86_64-linux"
       "i686-linux"
       "x86_64-darwin"
+      "aarch64-darwin"
       "aarch64-linux"
       "armv6l-linux"
       "armv7l-linux"


### PR DESCRIPTION
My machine is on Apple Silicon and aarch64-darwin is one of the more common systems seen in nix.