### PR TITLE
fix: Needs the correct package for nix-prefetch-github

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -33,6 +33,7 @@
           statix
           nix-prefetch
           nix-prefetch-scripts
+          nix-prefetch-github
           nix-tree
           ripgrep
         ];


### PR DESCRIPTION
The devshell seemed to be missing this package for creating a new xontrib.