### PR TITLE
feat: Add xontrib-broot

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -13,6 +13,7 @@
 
   xontrib-abbrevs = pkgs.callPackage ./pkgs/xontrib-abbrevs {};
   xontrib-bashisms = pkgs.callPackage ./pkgs/xontrib-bashisms {};
+  xontrib-broot = pkgs.callPackage ./pkgs/xontrib-broot {};
   xontrib-chatgpt = pkgs.callPackage ./pkgs/xontrib-chatgpt {};
   xontrib-clp = pkgs.callPackage ./pkgs/xontrib-clp {};
   xontrib-debug-tools = pkgs.callPackage ./pkgs/xontrib-debug-tools {};

--- a/pkgs/xontrib-broot/default.nix
+++ b/pkgs/xontrib-broot/default.nix
@@ -17,14 +17,11 @@ in
 
     doCheck = false;
     format = "pyproject";
-    # nativeBuildInputs = with pkgs.python3Packages; [
-    #   setuptools
-    #   poetry-core
-    # ];
-    buildInputs = with pkgs.python3Packages; [
+    build-system = with pkgs.python3Packages; [
       setuptools
       pdm-pep517
       poetry-core
+      pkgs.xonsh
     ];
 
     meta = {

--- a/pkgs/xontrib-broot/default.nix
+++ b/pkgs/xontrib-broot/default.nix
@@ -15,7 +15,7 @@ in
       sha256 = "sha256-9GqsTVCMvrWpTopHtEdicTyYRQzP1NVtQHZsfBT+fUg=";
     };
 
-    doCheck = true;
+    doCheck = false;
     format = "pyproject";
     # nativeBuildInputs = with pkgs.python3Packages; [
     #   setuptools

--- a/pkgs/xontrib-broot/default.nix
+++ b/pkgs/xontrib-broot/default.nix
@@ -1,0 +1,35 @@
+{
+  pkgs,
+  python3,
+}: let
+  pname = "xontrib-broot";
+  version = "0.2.1";
+in
+  python3.pkgs.buildPythonPackage {
+    inherit pname version;
+
+    src = pkgs.fetchFromGitHub {
+      owner = "jnoortheen";
+      repo = "xontrib-broot";
+      rev = "6f658ff88aba27b921017297d8c2c3dfb2ffa332";
+      sha256 = "sha256-9GqsTVCMvrWpTopHtEdicTyYRQzP1NVtQHZsfBT+fUg=";
+    };
+
+    doCheck = true;
+    format = "pyproject";
+    # nativeBuildInputs = with pkgs.python3Packages; [
+    #   setuptools
+    #   poetry-core
+    # ];
+    buildInputs = with pkgs.python3Packages; [
+      setuptools
+      pdm-pep517
+      poetry-core
+    ];
+
+    meta = {
+      homepage = "https://github.com/jnoortheen/xontrib-broot";
+      license = pkgs.lib.licenses.mit;
+      description = "[how-to use in nix](https://github.com/drmikecrowe/nur-packages) xonsh direnv";
+    };
+  }


### PR DESCRIPTION
It builds but I can't test as that means getting my fork setup as a NUR repo, which seems a bit too much effort.

This uses poetry, note that you don't need the patchPhase you had in xontrib-term-integrations as you can set format = "pyproject"; 