### PR TITLE
Create overlay of packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,38 @@ in {
 }
 ```
 
+Probably the easiest way to use this is as an overlay for nixpkgs. In your flake, add both
+this repository and nixpkgs. Then apply this overlay when you import the nixpkgs overlay.
+
+```
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/unstable";
+    xonsh-xontrib.url = "github:drmikecrowe/nur-packages";
+  };
+
+  outputs = { self, nixpkgs, xonsh-xontrib, ... }@inputs: {
+  let
+    packageSet = system: (import nixpkgs { inherit system; overlays = [ xonsh-xontrib.overlays ]; };
+  in {
+    devShells.x86_64-linux = let
+        pkgs = packageSet "x86_64-linux";
+    in {
+      buildInputs = with pkgs; [
+        xonsh.override {
+          extraPackages = (ps: [
+            ps.xonsh-direnv
+            ps.xontrib-vox
+          ]);
+        }
+      ];
+    };
+  };
+}
+```
+
+You should be able to use this similarly wherever you import nixpkgs by setting it as one over the overlays.
+
 ## Cachix Public Keys
 
 - [https://xonsh-xontribs.cachix.org](https://xonsh-xontribs.cachix.org)

--- a/flake.nix
+++ b/flake.nix
@@ -23,6 +23,7 @@
         pkgs = import nixpkgs {inherit system;};
       });
     packages = forAllSystems (system: nixpkgs.lib.filterAttrs (_: v: nixpkgs.lib.isDerivation v) self.legacyPackages.${system});
+    overlays = import ./overlay.nix;
     devShells = forAllSystems (system: let
       pkgs = nixpkgs.legacyPackages.${system};
     in {

--- a/overlay.nix
+++ b/overlay.nix
@@ -9,7 +9,11 @@ self: super: let
   };
   nurAttrs = import ./default.nix {pkgs = super;};
 in
-  builtins.listToAttrs
-  (map (n: nameValuePair n nurAttrs.${n})
-    (builtins.filter (n: !isReserved n)
-      (builtins.attrNames nurAttrs)))
+{
+  pythonPackagesExtensions = (super.pythonPackagesExtensions or []) ++[
+    (python-self: python-super: builtins.listToAttrs
+      (map (n: nameValuePair n nurAttrs.${n})
+        (builtins.filter (n: !isReserved n)
+          (builtins.attrNames nurAttrs))))
+  ];
+}


### PR DESCRIPTION
I cannibalized the existing code that read all packages as the overlays,
and just pushed it all into the Python overlay. This allows the packages
from this repository to be picked up in an overlay and added to the
existing libraries in Python.
