### PR TITLE
Set format = setuptools for python packages

### DIFF
--- a/pkgs/backtrace/default.nix
+++ b/pkgs/backtrace/default.nix
@@ -8,6 +8,7 @@
 buildPythonPackage rec {
   pname = "backtrace";
   version = "0.2.1+";
+  format = "setuptools";
   src = fetchFromGitHub {
     owner = "nir0s";
     repo = "backtrace";

--- a/pkgs/xonsh-direnv/default.nix
+++ b/pkgs/xonsh-direnv/default.nix
@@ -8,6 +8,7 @@
 buildPythonPackage rec {
   pname = "xontrib-xonsh-direnv";
   version = "1.6.3";
+  format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "74th";

--- a/pkgs/xontrib-chatgpt/default.nix
+++ b/pkgs/xontrib-chatgpt/default.nix
@@ -9,6 +9,7 @@
 buildPythonPackage rec {
   pname = "xontrib-chatgpt";
   version = "0.2.3";
+  format = "setuptools";
   src = fetchFromGitHub {
     owner = "drmikecrowe";
     repo = "xontrib-chatgpt";

--- a/pkgs/xontrib-clp/default.nix
+++ b/pkgs/xontrib-clp/default.nix
@@ -8,6 +8,7 @@
 buildPythonPackage {
   pname = "xontrib-clp";
   version = "0.1.6";
+  format = "setuptools";
   src = fetchFromGitHub {
     owner = "anki-code";
     repo = "xontrib-clp";

--- a/pkgs/xontrib-debug-tools/default.nix
+++ b/pkgs/xontrib-debug-tools/default.nix
@@ -8,6 +8,7 @@
 buildPythonPackage rec {
   pname = "xontrib-debug-tools";
   version = "0.0.1";
+  format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "xonsh";

--- a/pkgs/xontrib-dot-dot/default.nix
+++ b/pkgs/xontrib-dot-dot/default.nix
@@ -8,6 +8,7 @@
 buildPythonPackage {
   pname = "xontrib-dotdot";
   version = "0.1.0";
+  format = "setuptools";
   src = fetchFromGitHub {
     owner = "yggdr";
     repo = "xontrib-dotdot";

--- a/pkgs/xontrib-fish-completer/default.nix
+++ b/pkgs/xontrib-fish-completer/default.nix
@@ -9,6 +9,7 @@
 buildPythonPackage rec {
   pname = "xontrib-fish-completer";
   version = "0.0.1";
+  format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "xonsh";

--- a/pkgs/xontrib-prompt-starship/default.nix
+++ b/pkgs/xontrib-prompt-starship/default.nix
@@ -8,6 +8,7 @@
 buildPythonPackage {
   pname = "xontrib-prompt-starship";
   version = "0.3.6";
+  format = "setuptools";
   src = fetchFromGitHub {
     owner = "anki-code";
     repo = "xontrib-prompt-starship";

--- a/pkgs/xontrib-readable-traceback/default.nix
+++ b/pkgs/xontrib-readable-traceback/default.nix
@@ -7,6 +7,7 @@
 buildPythonPackage rec {
   pname = "xontrib-readable-traceback";
   version = "0.4.0";
+  format = "setuptools";
   src = fetchFromGitHub {
     owner = "vaaaaanquish";
     repo = "xontrib-readable-traceback";

--- a/pkgs/xontrib-sh/default.nix
+++ b/pkgs/xontrib-sh/default.nix
@@ -8,6 +8,7 @@
 buildPythonPackage {
   pname = "xontrib-sh";
   version = "0.3.1";
+  format = "setuptools";
   src = fetchFromGitHub {
     owner = "anki-code";
     repo = "xontrib-sh";

--- a/pkgs/xontrib-vox/default.nix
+++ b/pkgs/xontrib-vox/default.nix
@@ -10,6 +10,7 @@
 buildPythonPackage rec {
   pname = "xontrib-vox";
   version = "0.0.1";
+  format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "xonsh";

--- a/pkgs/xontrib-whole-word-jumping/default.nix
+++ b/pkgs/xontrib-whole-word-jumping/default.nix
@@ -8,6 +8,7 @@
 buildPythonPackage rec {
   pname = "xontrib-whole-word-jumping";
   version = "0.0.1";
+  format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "xonsh";


### PR DESCRIPTION
Due to https://github.com/NixOS/nixpkgs/pull/421660 all python packages require `format` or `pyproject`.

This PR sets `format = "setuptools"` for all packages where neither is specified.
Tested via `repoOverrides` for NUR overlay (but only some packages).

Example of current error:
``error: python3.13-xontrib-clp-0.1.6 does not configure a `format`. To build with setuptools as before, set `pyproject = true` and `build-system = [ setuptools ]`.``